### PR TITLE
Update Resurgence Field ID Constant

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -8,7 +8,8 @@ export const MATCHES = {
 	STATS: "Stats",
 	MATCH_TYPE: "Match Type",
 	RESURGENCE: "Resurgence?",
-	MINIS: "Minis?"
+	MINIS: "Minis?",
+	RANKED: "Ranked?"
 };
 
 // Members table fields

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -7,7 +7,7 @@ export const MATCHES = {
 	TEAM_DMG: "Team dmg",
 	STATS: "Stats",
 	MATCH_TYPE: "Match Type",
-	RESURGENCE: "Resurgence? (Quads)",
+	RESURGENCE: "Resurgence?",
 	MINIS: "Minis?"
 };
 


### PR DESCRIPTION
### Overview

This PR updates the `MATCHES.RESURGENCE` value to match the change in the Airtable field.

The constant property/value is not consumed by any code yet, so this change is non-breaking.

### Updates

- Added `Ranked?` field ID to constants